### PR TITLE
Fix menu spacing, limit about page width, and validate contact form

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,7 +37,7 @@
 
 <section class="contact fade-in-section">
   <h2>Contact Me</h2>
-  <form class="contact-form" action="mailto:charlescruz.k@me.com" method="POST" enctype="text/plain">
+  <form id="contactForm" class="contact-form">
     <label for="name">Name</label>
     <input type="text" id="name" name="name" required>
 

--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,7 @@ body {
   background: #fff;
   color: #111;
   margin: 0;
-  padding: 4rem 5vw 0; /* leave space for fixed nav */
+  padding: 4rem 8vw 0; /* leave space for fixed nav */
   line-height: 1.6;
 }
 header {
@@ -17,7 +17,7 @@ header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 5vw;
+  padding: 1rem 8vw;
   position: fixed; /* keep menu visible */
   top: 0;
   left: 0;
@@ -298,4 +298,13 @@ footer {
 }
 .contact-form button:hover {
   background-color: #45a049;
+}
+
+@media screen and (min-width: 1024px) {
+  .intro,
+  .contact {
+    width: 66%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }

--- a/js/script-combined.js
+++ b/js/script-combined.js
@@ -128,4 +128,30 @@ document.addEventListener("DOMContentLoaded", function () {
       updateSlider(e.touches[0].clientX);
     });
   });
+
+  /* Contact form handling */
+  const contactForm = document.getElementById('contactForm');
+  if (contactForm) {
+    contactForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+
+      const name = document.getElementById('name').value.trim();
+      const emailInput = document.getElementById('email');
+      const subject = document.getElementById('subject').value.trim();
+      const message = document.getElementById('message').value.trim();
+
+      if (!subject) {
+        alert('Please enter a subject.');
+        return;
+      }
+
+      if (!emailInput.checkValidity()) {
+        alert('Please enter a valid email address.');
+        return;
+      }
+
+      const mailtoLink = `mailto:charlescruz.k@me.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent('Name: ' + name + '\nEmail: ' + emailInput.value + '\n\n' + message)}`;
+      window.location.href = mailtoLink;
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- increase body/nav padding so menu items aren't stuck to the edge
- limit width of about page sections on large screens
- replace mailto form with JS-driven mailto link
- validate subject and email before opening mail client

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68846cf809188331b8f6cd610fa50cce