### PR TITLE
Update image scaling for portfolio

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -106,9 +106,13 @@ section { margin-bottom: 3.5rem; }
   position: relative;
   overflow: hidden;
   cursor: zoom-in;
+  /* Force a consistent aspect ratio so images crop uniformly */
+  aspect-ratio: 2 / 3;
 }
 .grid-item img {
   width: 100%;
+  height: 100%;
+  object-fit: cover;
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 .grid-item:hover img {


### PR DESCRIPTION
## Summary
- ensure images within grid layout use `object-fit: cover`
- keep a consistent `2 / 3` aspect ratio for grid items

## Testing
- `apt-get install -y file`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688481b98a888331b293efaf25328037